### PR TITLE
Fix shift tests

### DIFF
--- a/lib/shift_calculator.rb
+++ b/lib/shift_calculator.rb
@@ -33,6 +33,6 @@ class ShiftCalculator
 
   # needs tests
   def key_range(type)
-    @key_base[(type.ord - 97)..(type.ord - 96)].to_i
+    key_base[(type.ord - 97)..(type.ord - 96)].to_i
   end
 end

--- a/lib/shift_calculator.rb
+++ b/lib/shift_calculator.rb
@@ -21,17 +21,10 @@ class ShiftCalculator
     key_str
   end
 
-  # doesn't store one value throughout
-  # def key_base
-    # key_gen
-  # end
-  # could use a third method to hold instance attr key_key = @key_base, stub key key
-
   def shift(type)
     key_range(type) + offset_number[type.ord - 97].to_i
   end
 
-  # needs tests
   def key_range(type)
     key_base[(type.ord - 97)..(type.ord - 96)].to_i
   end

--- a/test/shift_calculator_test.rb
+++ b/test/shift_calculator_test.rb
@@ -25,7 +25,6 @@ class ShiftCalculatorTest < Minitest::Test
   end
 
   def test_it_calculates_total_shifts
-    skip
     @sc2 = ShiftCalculator.new
     @sc2.stubs(:offset_number).returns('4441')
     @sc2.stubs(:key_base).returns('12345')
@@ -36,7 +35,12 @@ class ShiftCalculatorTest < Minitest::Test
     assert_equal 46, @sc2.shift('d')
   end
 
-  def test_it_rejects_invalid_shift_types
-    skip
+  def test_key_range_gets_valid_values
+    @sc.stubs(:key_base).returns('12345')
+
+    assert_equal 12, @sc.key_range('a')
+    assert_equal 23, @sc.key_range('b')
+    assert_equal 34, @sc.key_range('c')
+    assert_equal 45, @sc.key_range('d')
   end
 end


### PR DESCRIPTION
Fix method call in key range method to allow stubbing return values and testing total shift. Also add test for key range method returns 